### PR TITLE
fix: avoid transpiling web worker of map

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.15.5",
-    "react-map-gl": "^5.2.11",
+    "react-map-gl": "^7.0.9",
     "react-query": "^3.34.16",
     "react-router-dom": "6",
     "react-scripts": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.15.5",
-    "react-map-gl": "^7.0.9",
+    "react-map-gl": "^5.2.11",
     "react-query": "^3.34.16",
     "react-router-dom": "6",
     "react-scripts": "5.0.0",
@@ -66,9 +66,8 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "defaults",
+      "not ie 11"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
Issue stems from transpiling the web worker to ES5, not working. I adjusted the transpiling settings.