### PR TITLE
fix: Avoid 401 errors

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,36 +20,37 @@ import { NotFound } from "./pages/notFound";
 import { ResetPassword } from "./pages/resetPassword";
 import { AuthProvider } from "./others/contexts/auth";
 import { FilterContextProvider } from "./others/contexts/filter";
-import { FileDownloaderContextProvider } from "./others/contexts/file-downloader";
+
+const Providers: React.FunctionComponent = ({ children }) => (
+  <AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <MuiThemeProvider theme={muiTheme}>
+        <DictionaryContextProvider>
+          <SidebarContextProvider>
+            <FilterContextProvider>{children}</FilterContextProvider>
+          </SidebarContextProvider>
+        </DictionaryContextProvider>
+      </MuiThemeProvider>
+    </QueryClientProvider>
+  </AuthProvider>
+);
 
 ReactDOM.render(
   <React.StrictMode>
-    <AuthProvider>
-      <QueryClientProvider client={queryClient}>
-        <MuiThemeProvider theme={muiTheme}>
-          <DictionaryContextProvider>
-            <SidebarContextProvider>
-              <FilterContextProvider>
-                <FileDownloaderContextProvider>
-                  <CssBaseline />
-                  <BrowserRouter>
-                    <Routes>
-                      <Route path="/login" element={<Login />} />
-                      <Route path="/reset-password" element={<ResetPassword />} />
-                      <Route element={<AuthWrapper />}>
-                        <Route path="/" element={<Home />} />
-                        <Route path="/requests" element={<Requests />} />
-                      </Route>
-                      <Route path="*" element={<NotFound />} />
-                    </Routes>
-                  </BrowserRouter>
-                </FileDownloaderContextProvider>
-              </FilterContextProvider>
-            </SidebarContextProvider>
-          </DictionaryContextProvider>
-        </MuiThemeProvider>
-      </QueryClientProvider>
-    </AuthProvider>
+    <Providers>
+      <CssBaseline />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/reset-password" element={<ResetPassword />} />
+          <Route element={<AuthWrapper />}>
+            <Route path="/" element={<Home />} />
+            <Route path="/requests" element={<Requests />} />
+          </Route>
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </BrowserRouter>
+    </Providers>
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/src/others/components/AuthWrapper.tsx
+++ b/src/others/components/AuthWrapper.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 
 import { AuthStatus, useAuth } from "../contexts/auth";
+import { FileDownloaderContextProvider } from "../contexts/file-downloader";
 
 export interface AuthWrapperProps {}
 
@@ -17,5 +18,9 @@ export const AuthWrapper: React.FunctionComponent<AuthWrapperProps> = () => {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
-  return <Outlet />;
+  return (
+    <FileDownloaderContextProvider>
+      <Outlet />
+    </FileDownloaderContextProvider>
+  );
 };

--- a/src/others/contexts/api.tsx
+++ b/src/others/contexts/api.tsx
@@ -25,7 +25,7 @@ export interface Location {
 }
 
 function useFetch() {
-  const { session } = useAuth();
+  const { forceSessionRefresh, session } = useAuth();
 
   const query = React.useCallback(
     (input: RequestInfo, init?: RequestInit) => {
@@ -34,9 +34,15 @@ function useFetch() {
           Authorization: session?.accessToken.jwtToken || "",
         },
         ...init,
+      }).then((res) => {
+        if (res.status === 401) {
+          forceSessionRefresh();
+        }
+
+        return res;
       });
     },
-    [session]
+    [forceSessionRefresh, session]
   );
 
   return {


### PR DESCRIPTION
The issue with 401 in dev was:
1. If you stayed inactive for an hour with the tab open, we don't have a refresh mechanism
2. A call to the API was not made behind the Auth Wrapper

Solved it by adding the refresh mechanism and moving the provider to the AuthWrapper