### PR TITLE
added tooltips to header icons

### DIFF
--- a/src/media/translations/en.json
+++ b/src/media/translations/en.json
@@ -61,5 +61,7 @@
   "requests": "requests",
   "no_results": "No matching search results",
   "search_city_placeholder": "Search for city",
-  "loading": "Loading"
+  "loading": "Loading",
+  "logout": "Logout",
+  "download_requests": "Download requests"
 }

--- a/src/media/translations/uk.json
+++ b/src/media/translations/uk.json
@@ -64,6 +64,6 @@
   "no_results": "Нічого не знайдено",
   "search_city_placeholder": "Пошук міста",
   "loading": "Завантажується",
-  "logout": "",
-  "download_requests": ""
+  "logout": "Вийти",
+  "download_requests": "Завантажити дані"
 }

--- a/src/media/translations/uk.json
+++ b/src/media/translations/uk.json
@@ -63,5 +63,7 @@
   "requests": "запитів",
   "no_results": "Нічого не знайдено",
   "search_city_placeholder": "Пошук міста",
-  "loading": "Завантажується"
+  "loading": "Завантажується",
+  "logout": "",
+  "download_requests": ""
 }

--- a/src/others/components/Header.tsx
+++ b/src/others/components/Header.tsx
@@ -7,7 +7,7 @@ import IconButton from "@mui/material/IconButton";
 import MenuIcon from "@mui/icons-material/Menu";
 import OutputIcon from "@mui/icons-material/Output";
 import { FilterDropdownGroup } from "./FilterDropdown/FilterDropdownGroup";
-import { Box } from "@mui/material";
+import { Box, Tooltip } from "@mui/material";
 
 import { useFilter } from "../contexts/filter";
 import { useAuth } from "../contexts/auth";
@@ -53,10 +53,14 @@ export const Header = ({ aidRequests, children }: HeaderProps) => {
         </Box>
         {children}
         <LanguageSelector />
-        <Box sx={{ justifySelf: "flex-end" }}>
-          <FileDownloaderMenu aidRequests={aidRequests} />
-        </Box>
-        <OutputIcon onClick={logout} sx={{ width: 30, height: 30, marginLeft: "auto", cursor: "pointer" }} />
+        <Tooltip title={t("download_requests") as string} arrow>
+          <Box sx={{ justifySelf: "flex-end" }}>
+            <FileDownloaderMenu aidRequests={aidRequests} />
+          </Box>
+        </Tooltip>
+        <Tooltip title={t("logout") as string} arrow>
+          <OutputIcon onClick={logout} sx={{ width: 30, height: 30, marginLeft: "auto", cursor: "pointer" }} />
+        </Tooltip>
       </Toolbar>
     </AppBar>
   );

--- a/src/others/components/LanguageSelector.tsx
+++ b/src/others/components/LanguageSelector.tsx
@@ -63,7 +63,7 @@ export const LanguageSelector: FunctionComponent<LanguageSelectorProps> = () => 
       <div style={{
         cursor: "pointer",
         borderRadius: "20px",
-        width: "fit-content",
+        width: "90px",
         padding: "10px 15px",
         backgroundColor: "#fff",
         color: "#000"
@@ -75,7 +75,7 @@ export const LanguageSelector: FunctionComponent<LanguageSelectorProps> = () => 
         <div style={{
           cursor: "pointer",
           borderRadius: "20px",
-          width: "fit-content",
+          width: "90px",
           padding: "10px 15px",
           backgroundColor: "#fff",
           color: "#000",


### PR DESCRIPTION
Added tooltips to header icons + minor styling fix for language switcher.

<img width="214" alt="Screen Shot 2022-03-27 at 7 29 08 PM" src="https://user-images.githubusercontent.com/5226211/160305922-1efb2082-b777-4cb3-b953-494a9b805cc0.png">

<img width="210" alt="Screen Shot 2022-03-27 at 7 29 15 PM" src="https://user-images.githubusercontent.com/5226211/160305926-248a28d5-d1d5-4c14-b92a-9bac033d0d12.png">

Before:
![UGT-Request](https://user-images.githubusercontent.com/5226211/160305979-27e49ca4-fb2b-4ced-ba0c-f47787f3c537.png)

After:
<img width="145" alt="Screen Shot 2022-03-27 at 7 28 34 PM" src="https://user-images.githubusercontent.com/5226211/160305969-3a385ba5-aa1b-4103-9930-0c1e9a1118ee.png">

